### PR TITLE
Change script link to verbose from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ just follow the guide below and stay notified of your build status.
 
     ```yaml
     after_success:
-      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/verbose/send.sh
       - chmod +x send.sh
       - ./send.sh success $WEBHOOK_URL
     after_failure:
-      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
+      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/verbose/send.sh
       - chmod +x send.sh
       - ./send.sh failure $WEBHOOK_URL
     ```


### PR DESCRIPTION
This branch should have link for the `send.sh` referring to this branch itself and not the one in the master branch (unless obviously this is meant to be merged with the main branch, which it shouldn't)