### PR TITLE
Replace line feeds with literals (\n)

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -29,7 +29,7 @@ esac
 AUTHOR_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%aN")"
 COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
 COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
-COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")"
+COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
 
 if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
   CREDITS="$AUTHOR_NAME authored & committed"


### PR DESCRIPTION
Discord doesn't like line feeds in it's JSON it seems.
Replace them by literals (\n) instead.

Note that I only tested this for my specific case and copied the code from this stackoverflow answer: https://stackoverflow.com/questions/38672680/replace-newlines-with-literal-n/38672741#38672741

This fixed #21 in my specific case.

(Fixes #21)