### PR TITLE
Fix #27

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -32,12 +32,12 @@ COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
 COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
 
 if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
-  COMMIT_SUBJECT = "$(echo "$COMMIT_SUBJECT" | cut -c 1-250)"
+  COMMIT_SUBJECT="$(echo "$COMMIT_SUBJECT" | cut -c 1-250)"
   COMMIT_SUBJECT+="..."
 fi
 
 if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 2048 ]; then
-  COMMIT_MESSAGE = "$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
+  COMMIT_MESSAGE="$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
   COMMIT_MESSAGE+="..."
 fi
 

--- a/send.sh
+++ b/send.sh
@@ -31,8 +31,13 @@ COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
 COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
 COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
 
-if [ ${#COMMIT_MESSAGE} > 200 ]; then
-  COMMIT_MESSAGE = "$(echo "$COMMIT_MESSAGE" | cut -c 1-197)"
+if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
+  COMMIT_SUBJECT = "$(echo "$COMMIT_SUBJECT" | cut -c 1-250)"
+  COMMIT_SUBJECT+="..."
+fi
+
+if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 2048 ]; then
+  COMMIT_MESSAGE = "$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
   COMMIT_MESSAGE+="..."
 fi
 

--- a/send.sh
+++ b/send.sh
@@ -32,7 +32,7 @@ COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
 COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
 
 if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
-  COMMIT_SUBJECT="$(echo "$COMMIT_SUBJECT" | cut -c 1-250)"
+  COMMIT_SUBJECT="$(echo "$COMMIT_SUBJECT" | cut -c 1-253)"
   COMMIT_SUBJECT+="..."
 fi
 

--- a/send.sh
+++ b/send.sh
@@ -36,7 +36,7 @@ if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
   COMMIT_SUBJECT+="..."
 fi
 
-if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 2048 ]; then
+if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 1900 ]; then
   COMMIT_MESSAGE="$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
   COMMIT_MESSAGE+="..."
 fi

--- a/send.sh
+++ b/send.sh
@@ -31,6 +31,11 @@ COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
 COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
 COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
 
+if [ ${#COMMIT_MESSAGE} > 200 ]; then
+  COMMIT_MESSAGE = "$(echo "$COMMIT_MESSAGE" | cut -c 1-197)"
+  COMMIT_MESSAGE+="..."
+fi
+
 if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
   CREDITS="$AUTHOR_NAME authored & committed"
 else


### PR DESCRIPTION
Referencing to [Discord Developer Portal](https://discord.com/developers/docs/resources/channel#embed-limits): 
* The field *title* can't exceed 256 characters and it's corresponding to *COMMIT_SUBJECT* variable.
* Same test on the limit with the *COMMIT_MESSAGE* just in case for the field *description* which can't exceed 2048 characters (I've take in consideration the variable *CREDITS*).