### PR TITLE
adding support for travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ just follow the guide below and stay notified of your build status.
       - chmod +x send.sh
       - ./send.sh failure $WEBHOOK_URL
     ```
+    If you use travis-ci.com, Add these instead.
+
+    ```yaml
+    after_success:
+      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send2.sh
+      - chmod +x send2.sh
+      - ./send2.sh success $WEBHOOK_URL
+    after_failure:
+      - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send2.sh
+      - chmod +x send2.sh
+      - ./send2.sh failure $WEBHOOK_URL
+    ```
 
 1.  Grab your coffee ☕ and enjoy! And, if you liked this, please ⭐**Star**
     this repository to show your love.

--- a/send2.sh
+++ b/send2.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+if [ -z "$2" ]; then
+  echo -e "WARNING!!\nYou need to pass the WEBHOOK_URL environment variable as the second argument to this script.\nFor details & guide, visit: https://github.com/DiscordHooks/travis-ci-discord-webhook" && exit
+fi
+
+echo -e "[Webhook]: Sending webhook to Discord...\\n";
+
+case $1 in
+  "success" )
+    EMBED_COLOR=3066993
+    STATUS_MESSAGE="Passed"
+    AVATAR="https://travis-ci.com/images/logos/TravisCI-Mascot-blue.png"
+    ;;
+
+  "failure" )
+    EMBED_COLOR=15158332
+    STATUS_MESSAGE="Failed"
+    AVATAR="https://travis-ci.com/images/logos/TravisCI-Mascot-red.png"
+    ;;
+
+  * )
+    EMBED_COLOR=0
+    STATUS_MESSAGE="Status Unknown"
+    AVATAR="https://travis-ci.com/images/logos/TravisCI-Mascot-1.png"
+    ;;
+esac
+
+AUTHOR_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%aN")"
+COMMITTER_NAME="$(git log -1 "$TRAVIS_COMMIT" --pretty="%cN")"
+COMMIT_SUBJECT="$(git log -1 "$TRAVIS_COMMIT" --pretty="%s")"
+COMMIT_MESSAGE="$(git log -1 "$TRAVIS_COMMIT" --pretty="%b")" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g'
+
+if [ ${#COMMIT_SUBJECT} -gt 256 ]; then
+  COMMIT_SUBJECT="$(echo "$COMMIT_SUBJECT" | cut -c 1-253)"
+  COMMIT_SUBJECT+="..."
+fi
+
+if [ -n $COMMIT_MESSAGE ] && [ ${#COMMIT_MESSAGE} -gt 1900 ]; then
+  COMMIT_MESSAGE="$(echo "$COMMIT_MESSAGE" | cut -c 1-1900)"
+  COMMIT_MESSAGE+="..."
+fi
+
+if [ "$AUTHOR_NAME" == "$COMMITTER_NAME" ]; then
+  CREDITS="$AUTHOR_NAME authored & committed"
+else
+  CREDITS="$AUTHOR_NAME authored & $COMMITTER_NAME committed"
+fi
+
+if [[ $TRAVIS_PULL_REQUEST != false ]]; then
+  URL="https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST"
+else
+  URL=""
+fi
+
+TIMESTAMP=$(date --utc +%FT%TZ)
+WEBHOOK_DATA='{
+  "username": "",
+  "avatar_url": "https://travis-ci.com/images/logos/TravisCI-Mascot-1.png",
+  "embeds": [ {
+    "color": '$EMBED_COLOR',
+    "author": {
+      "name": "Job #'"$TRAVIS_JOB_NUMBER"' (Build #'"$TRAVIS_BUILD_NUMBER"') '"$STATUS_MESSAGE"' - '"$TRAVIS_REPO_SLUG"'",
+      "url": "'"$TRAVIS_BUILD_WEB_URL"'",
+      "icon_url": "'$AVATAR'"
+    },
+    "title": "'"$COMMIT_SUBJECT"'",
+    "url": "'"$URL"'",
+    "description": "'"${COMMIT_MESSAGE//$'\n'/ }"\\n\\n"$CREDITS"'",
+    "fields": [
+      {
+        "name": "Commit",
+        "value": "'"[\`${TRAVIS_COMMIT:0:7}\`](https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT)"'",
+        "inline": true
+      },
+      {
+        "name": "Branch",
+        "value": "'"[\`$TRAVIS_BRANCH\`](https://github.com/$TRAVIS_REPO_SLUG/tree/$TRAVIS_BRANCH)"'",
+        "inline": true
+      }
+    ],
+    "timestamp": "'"$TIMESTAMP"'"
+  } ]
+}'
+
+(curl --fail --progress-bar -A "TravisCI-Webhook" -H Content-Type:application/json -H X-Author:k3rn31p4nic#8383 -d "${WEBHOOK_DATA//	/ }" "$2" \
+  && echo -e "\\n[Webhook]: Successfully sent the webhook.") || echo -e "\\n[Webhook]: Unable to send webhook."


### PR DESCRIPTION
i was super confused when the travis vot was showing success and github showing failure
turns out your script uses travis-ci.org!
according to travis them selves new users should use travis-ci.com 
so i added an alternative script for travis-ci.com